### PR TITLE
chore: a dotenv example field is now mandatory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,10 @@ REACT_APP_BEARER_TOKEN=
 # Do not include / at the end.
 REACT_APP_CORS_PROXY_URL=https://cors-anywhere.herokuapp.com
 
-# All fields below this line are optional -------------
-
 # If the user selects one of these addresses as the arbitrator on the factory, we can hide the arbitrator extra data field and display user friendly fields: Number of Jurors, Court.
 REACT_APP_KLEROS_ADDRESSES={"1":{"arbitrator":"0x988b3a538b618c7a603e1c11ab82cd16dbe28069","policy":"0xCf1f07713d5193FaE5c1653C9f61953D048BECe4","uiURL":"https://court.kleros.io/cases/:disputeID"},"42":{"arbitrator":"0x60b2abfdfad9c0873242f59f2a8c32a3cc682f80","policy":"0xfc53d1d6ddc2c6cdd403cb7dbf0f26140d82e12d","uiURL":"https://court.kleros.io/cases/:disputeID"},"100":{"arbitrator":"0x9C1dA9A04925bDfDedf0f6421bC7EEa8305F9002","policy":"0x9d494768936b6bDaabc46733b8D53A937A6c6D7e","uiURL":"https://court.kleros.io/cases/:disputeID"}}
+
+# All fields below this line are optional -------------
 
 REACT_APP_WALLETCONNECT_BRIDGE_URL=https://bridge.walletconnect.org
 REACT_APP_NOTIFICATIONS_API_URL=


### PR DESCRIPTION
If not included in .env, crashes are possible
I've had one visiting this, due to `klerosAdress.toLowerCase()` not existing
[http://localhost:3000/tcr/0x1E9c3b5f57974beAdbd8C28Ba918d85b8477C618/0xeaf324befb5ea703654e1381484eef75459190c338a1bff1946db578b4a63003](url)