### PR TITLE
fix: infura getlogs outage

### DIFF
--- a/src/components/search-bar.js
+++ b/src/components/search-bar.js
@@ -20,6 +20,7 @@ import { ItemTypes, searchableFields } from '@kleros/gtcr-encoder'
 import { TCRViewContext } from 'contexts/tcr-view-context'
 import { WalletContext } from 'contexts/wallet-context'
 import { itemToStatusCode, STATUS_COLOR } from '../utils/item-status'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledSelect = styled(Select)`
   width: 100%;
@@ -170,6 +171,7 @@ const SearchBar = () => {
     tcrAddress
   } = useContext(TCRViewContext)
   const { library, active } = useWeb3Context()
+  const getLogs = useGetLogs(library)
 
   // If this is a TCR of TCRs, we should not only
   // match against the decoded item value but also against
@@ -197,7 +199,7 @@ const SearchBar = () => {
             try {
               // Take the latest meta evidence.
               const logs = (
-                await library.getLogs({
+                await getLogs({
                   ...arbitrable.filters.MetaEvidence(),
                   fromBlock: 0
                 })

--- a/src/hooks/get-logs.js
+++ b/src/hooks/get-logs.js
@@ -1,0 +1,19 @@
+import { ethers } from 'ethers'
+
+const useGetLogs = library => {
+  const key = JSON.parse(process.env.REACT_APP_RPC_URLS)[1]
+  const provider = new ethers.providers.JsonRpcProvider(key)
+
+  const getLogs = async query => {
+    if (library.network.chainId === 1) {
+      const mainnetResult = await provider.getLogs(query)
+      return mainnetResult
+    } else {
+      const defResult = await library.getLogs(query)
+      return defResult
+    }
+  }
+  return getLogs
+}
+
+export default useGetLogs

--- a/src/hooks/light-tcr-view.js
+++ b/src/hooks/light-tcr-view.js
@@ -8,6 +8,7 @@ import { abi as _arbitrator } from '@kleros/erc-792/build/contracts/IArbitrator.
 import getNetworkEnv from '../utils/network-env'
 import useNotificationWeb3 from './notifications-web3'
 import { getAddress } from 'ethers/utils'
+import useGetLogs from './get-logs'
 
 // TODO: Ensure we don't set state for unmounted components using
 // flags and AbortController.
@@ -33,6 +34,7 @@ const useLightTcrView = tcrAddress => {
     'REACT_APP_LGTCRVIEW_ADDRESSES',
     networkId
   )
+  const getLogs = useGetLogs(library)
 
   // Wire up the TCR.
   const gtcrView = useMemo(() => {
@@ -177,7 +179,7 @@ const useLightTcrView = tcrAddress => {
       try {
         // Take the latest meta evidence.
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...gtcr.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -243,7 +245,7 @@ const useLightTcrView = tcrAddress => {
     if (!gtcr || !library || gtcr.address !== tcrAddress) return
     ;(async () => {
       const logs = (
-        await library.getLogs({
+        await getLogs({
           ...gtcr.filters.ConnectedTCRSet(),
           fromBlock: 0
         })

--- a/src/hooks/meta-evidence.js
+++ b/src/hooks/meta-evidence.js
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
+import useGetLogs from './get-logs'
 
 const useMetaEvidence = ({ arbitrable, library }) => {
   const [metaEvidence, setMetaEvidence] = useState()
   const [error, setError] = useState()
+  const getLogs = useGetLogs(library)
 
   useEffect(() => {
     if (!arbitrable || !library) return
@@ -10,7 +12,7 @@ const useMetaEvidence = ({ arbitrable, library }) => {
       try {
         // Take the latest meta evidence.
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...arbitrable.filters.MetaEvidence(),
             fromBlock: 0
           })

--- a/src/hooks/tcr-view.js
+++ b/src/hooks/tcr-view.js
@@ -10,6 +10,7 @@ import { gtcrDecode } from '@kleros/gtcr-encoder'
 import useNotificationWeb3 from './notifications-web3'
 import { getAddress } from 'ethers/utils'
 import takeLower from '../utils/lower-limit'
+import useGetLogs from './get-logs'
 
 // TODO: Ensure we don't set state for unmounted components using
 // flags and AbortController.
@@ -36,7 +37,7 @@ const useTcrView = tcrAddress => {
     'REACT_APP_GTCRVIEW_ADDRESSES',
     networkId
   )
-
+  const getLogs = useGetLogs(library)
   // Wire up the TCR.
   const gtcrView = useMemo(() => {
     if (!library || !active || !arbitrableTCRViewAddr || !networkId) return
@@ -180,7 +181,7 @@ const useTcrView = tcrAddress => {
       try {
         // Take the latest meta evidence.
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...gtcr.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -246,7 +247,7 @@ const useTcrView = tcrAddress => {
     if (!gtcr || !library || gtcr.address !== tcrAddress) return
     ;(async () => {
       const logs = (
-        await library.getLogs({
+        await getLogs({
           ...gtcr.filters.ConnectedTCRSet(),
           fromBlock: 0
         })
@@ -271,7 +272,7 @@ const useTcrView = tcrAddress => {
       try {
         setItemSubmissionLogs(
           (
-            await library.getLogs({
+            await getLogs({
               ...gtcr.filters.ItemSubmitted(),
               fromBlock: 0
             })

--- a/src/pages/factory-classic/kleros-params.js
+++ b/src/pages/factory-classic/kleros-params.js
@@ -10,6 +10,7 @@ import ETHAmount from 'components/eth-amount'
 import { jurorsAndCourtIDFromExtraData } from 'utils/string'
 import useWindowDimensions from 'hooks/window-dimensions'
 import useNativeCurrency from 'hooks/native-currency'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledExtraDataContainer = styled.div`
   padding-bottom: 8px;
@@ -44,6 +45,7 @@ const KlerosParams = ({
   const [numberOfJurors, setNumberOfJurors] = useState(3)
   const [courtID, setCourtID] = useState()
   const [courts, setCourts] = useState([])
+  const getLogs = useGetLogs(library)
 
   const policyRegistry = useMemo(() => {
     if (!policyAddress || !active) return
@@ -74,7 +76,7 @@ const KlerosParams = ({
       if (!policyRegistry || !active) return
       try {
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...policyRegistry.filters.PolicyUpdate(),
             fromBlock: 0
           })

--- a/src/pages/factory/kleros-params.js
+++ b/src/pages/factory/kleros-params.js
@@ -10,6 +10,7 @@ import ETHAmount from 'components/eth-amount'
 import { jurorsAndCourtIDFromExtraData } from 'utils/string'
 import useWindowDimensions from 'hooks/window-dimensions'
 import useNativeCurrency from 'hooks/native-currency'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledExtraDataContainer = styled.div`
   padding-bottom: 8px;
@@ -44,6 +45,7 @@ const KlerosParams = ({
   const [numberOfJurors, setNumberOfJurors] = useState(3)
   const [courtID, setCourtID] = useState()
   const [courts, setCourts] = useState([])
+  const getLogs = useGetLogs(library)
 
   const policyRegistry = useMemo(() => {
     if (!policyAddress || !active) return
@@ -74,7 +76,7 @@ const KlerosParams = ({
       if (!policyRegistry || !active) return
       try {
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...policyRegistry.filters.PolicyUpdate(),
             fromBlock: 0
           })

--- a/src/pages/item-details/badges/index.js
+++ b/src/pages/item-details/badges/index.js
@@ -24,6 +24,7 @@ import SubmitModal from '../modals/submit'
 import SubmitConnectModal from '../modals/submit-connect'
 import useTcrView from 'hooks/tcr-view'
 import takeLower from 'utils/lower-limit'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledGrid = styled.div`
   display: grid;
@@ -88,6 +89,7 @@ const Badges = ({ connectedTCRAddr, item, tcrAddress }) => {
     isFetching: false,
     data: null
   })
+  const getLogs = useGetLogs(library)
 
   // Wire up the TCR.
   const gtcrView = useMemo(() => {
@@ -223,7 +225,7 @@ const Badges = ({ connectedTCRAddr, item, tcrAddress }) => {
 
             // Get the badge contract metadata.
             const logs = (
-              await library.getLogs({
+              await getLogs({
                 ...badgeContract.filters.MetaEvidence(),
                 fromBlock: 0
               })

--- a/src/pages/item-details/index.js
+++ b/src/pages/item-details/index.js
@@ -30,6 +30,7 @@ import Badges from './badges'
 import AppTour from 'components/tour'
 import itemTourSteps from './tour-steps'
 import takeLower from 'utils/lower-limit'
+import useGetLogs from 'hooks/get-logs'
 
 const ITEM_TOUR_DISMISSED = 'ITEM_TOUR_DISMISSED'
 
@@ -97,6 +98,7 @@ const ItemDetails = ({ itemID, search }) => {
     connectedTCRAddr,
     metadataByTime
   } = useContext(TCRViewContext)
+  const getLogs = useGetLogs(library)
 
   // Warning: This function should only be called when all its dependencies
   // are set.
@@ -119,7 +121,7 @@ const ItemDetails = ({ itemID, search }) => {
         if (!gtcr || !gtcrView || !tcrAddress || !itemID) return
         const [requestStructs, rawRequestLogs] = await Promise.all([
           gtcrView.getItemRequests(tcrAddress, itemID),
-          library.getLogs({
+          getLogs({
             ...gtcr.filters.RequestSubmitted(itemID),
             fromBlock: 0
           })
@@ -243,7 +245,7 @@ const ItemDetails = ({ itemID, search }) => {
       try {
         // Take the latest meta evidence.
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...itemTCR.filters.MetaEvidence(),
             fromBlock: 0
           })

--- a/src/pages/item-details/modals/submit-connect.js
+++ b/src/pages/item-details/modals/submit-connect.js
@@ -35,6 +35,7 @@ import { WalletContext } from 'contexts/wallet-context'
 import { gtcrEncode } from '@kleros/gtcr-encoder'
 import { TourContext } from 'contexts/tour-context.js'
 import useNativeCurrency from 'hooks/native-currency.js'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledSpin = styled(Spin)`
   height: 60px;
@@ -87,6 +88,7 @@ const SubmitConnectModal = props => {
   const [relTCRSubmissionDeposit, setRelTCRSubmissionDeposit] = useState()
 
   const [match, setMatch] = useState()
+  const getLogs = useGetLogs(library)
 
   // Set initial values, if any.
   useEffect(() => {
@@ -103,7 +105,7 @@ const SubmitConnectModal = props => {
       try {
         const tcr = new ethers.Contract(debouncedTCRAddr, _gtcr, library)
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...tcr.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -136,7 +138,7 @@ const SubmitConnectModal = props => {
           library
         )
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...badgeTCR.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -162,7 +164,7 @@ const SubmitConnectModal = props => {
       try {
         const relTCR = new ethers.Contract(relTCRAddress, _gtcr, library)
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...relTCR.filters.MetaEvidence(),
             fromBlock: 0
           })

--- a/src/pages/item-details/request-timelines/timeline.js
+++ b/src/pages/item-details/request-timelines/timeline.js
@@ -27,6 +27,7 @@ import { WalletContext } from 'contexts/wallet-context'
 import BNPropType from 'prop-types/bn'
 import { capitalizeFirstLetter } from 'utils/string'
 import { getTxPage } from 'utils/network-utils'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledText = styled(Typography.Text)`
   text-transform: capitalize;
@@ -91,6 +92,7 @@ const Timeline = ({ request, requestID, item }) => {
       solidityKeccak256(['bytes32', 'uint'], [itemID, requestID])
     )
   }, [itemID, requestID])
+  const getLogs = useGetLogs(library)
 
   // Setup arbitrator instance.
   useEffect(() => {
@@ -131,32 +133,32 @@ const Timeline = ({ request, requestID, item }) => {
       // Fetch logs in parallel.
       const logsArr = (
         await Promise.all([
-          library.getLogs({
+          getLogs({
             ...gtcr.filters.Evidence(arbitrator.address, evidenceGroupID),
             fromBlock: 0
           }),
-          library.getLogs({
+          getLogs({
             ...gtcr.filters.RequestSubmitted(itemID, requestID),
             fromBlock: 0
           }),
-          library.getLogs({
+          getLogs({
             ...gtcr.filters.ItemStatusChange(itemID, requestID),
             fromBlock: 0
           }),
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...gtcr.filters.Ruling(arbitrator.address, disputeID),
                 fromBlock: 0
               })
             : null,
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...arbitrator.filters.AppealPossible(disputeID, gtcrAddr),
                 fromBlock: 0
               })
             : null,
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...arbitrator.filters.AppealDecision(disputeID, gtcrAddr),
                 fromBlock: 0
               })

--- a/src/pages/items/index.js
+++ b/src/pages/items/index.js
@@ -39,6 +39,7 @@ import takeLower from 'utils/lower-limit'
 import { DISPUTE_STATUS } from 'utils/item-status'
 import { useLazyQuery } from '@apollo/client'
 import { CLASSIC_REGISTRY_ITEMS_QUERY } from 'utils/graphql'
+import useGetLogs from 'hooks/get-logs'
 
 const NSFW_FILTER_KEY = 'NSFW_FILTER_KEY'
 const ITEMS_TOUR_DISMISSED = 'ITEMS_TOUR_DISMISSED'
@@ -148,6 +149,7 @@ const Items = () => {
   const [nsfwFilterOn, setNSFWFilter] = useState(true)
   const [queryItemParams, setQueryItemParams] = useState()
   const [getItems, itemsQuery] = useLazyQuery(CLASSIC_REGISTRY_ITEMS_QUERY)
+  const getLogs = useGetLogs(library)
 
   const toggleNSFWFilter = useCallback(checked => {
     setNSFWFilter(checked)
@@ -373,7 +375,7 @@ const Items = () => {
             100) // Add 100 block margin.
       }
 
-      const requestSubmissionLogs = (await library.getLogs(logsFilter))
+      const requestSubmissionLogs = (await getLogs(logsFilter))
         .map(log => ({
           ...gtcr.interface.parseLog(log),
           blockNumber: log.blockNumber

--- a/src/pages/light-item-details/badges/index.js
+++ b/src/pages/light-item-details/badges/index.js
@@ -25,6 +25,7 @@ import takeLower from 'utils/lower-limit'
 import { useLazyQuery } from '@apollo/client'
 import { LIGHT_ITEMS_QUERY } from 'utils/graphql'
 import { bigNumberify } from 'ethers/utils'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledGrid = styled.div`
   display: grid;
@@ -160,6 +161,7 @@ const Badges = ({ connectedTCRAddr, item, tcrAddress }) => {
     isFetching: false,
     data: null
   })
+  const getLogs = useGetLogs(library)
 
   // Wire up the TCR.
   const gtcrView = useMemo(() => {
@@ -275,7 +277,7 @@ const Badges = ({ connectedTCRAddr, item, tcrAddress }) => {
             const badgeContract = new ethers.Contract(badgeAddr, _gtcr, library)
             // Get the badge contract metadata.
             const logs = (
-              await library.getLogs({
+              await getLogs({
                 ...badgeContract.filters.MetaEvidence(),
                 fromBlock: 0
               })

--- a/src/pages/light-item-details/index.js
+++ b/src/pages/light-item-details/index.js
@@ -32,6 +32,7 @@ import { SUBGRAPH_STATUS_TO_CODE } from 'utils/item-status'
 import { LIGHT_ITEM_DETAILS_QUERY } from 'utils/graphql'
 import { useQuery } from '@apollo/client'
 import SearchBar from 'components/light-search-bar'
+import useGetLogs from 'hooks/get-logs'
 
 const ITEM_TOUR_DISMISSED = 'ITEM_TOUR_DISMISSED'
 
@@ -99,6 +100,7 @@ const ItemDetails = ({ itemID, search }) => {
     connectedTCRAddr,
     metadataByTime
   } = useContext(LightTCRViewContext)
+  const getLogs = useGetLogs(library)
 
   // subgraph item entities have id "<itemID>@<listaddress>"
   const compoundId = `${itemID}@${tcrAddress.toLowerCase()}`
@@ -255,7 +257,7 @@ const ItemDetails = ({ itemID, search }) => {
       try {
         // Take the latest meta evidence.
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...itemTCR.filters.MetaEvidence(),
             fromBlock: 0
           })

--- a/src/pages/light-item-details/modals/submit-connect.js
+++ b/src/pages/light-item-details/modals/submit-connect.js
@@ -34,6 +34,7 @@ import ipfsPublish from 'utils/ipfs-publish'
 import { WalletContext } from 'contexts/wallet-context'
 import { TourContext } from 'contexts/tour-context.js'
 import useNativeCurrency from 'hooks/native-currency.js'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledSpin = styled(Spin)`
   height: 60px;
@@ -86,6 +87,7 @@ const SubmitConnectModal = props => {
   const [relTCRSubmissionDeposit, setRelTCRSubmissionDeposit] = useState()
 
   const [match, setMatch] = useState()
+  const getLogs = useGetLogs(library)
 
   // Set initial values, if any.
   useEffect(() => {
@@ -102,7 +104,7 @@ const SubmitConnectModal = props => {
       try {
         const tcr = new ethers.Contract(debouncedTCRAddr, _gtcr, library)
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...tcr.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -135,7 +137,7 @@ const SubmitConnectModal = props => {
           library
         )
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...badgeTCR.filters.MetaEvidence(),
             fromBlock: 0
           })
@@ -161,7 +163,7 @@ const SubmitConnectModal = props => {
       try {
         const relTCR = new ethers.Contract(relTCRAddress, _gtcr, library)
         const logs = (
-          await library.getLogs({
+          await getLogs({
             ...relTCR.filters.MetaEvidence(),
             fromBlock: 0
           })

--- a/src/pages/light-item-details/request-timelines/timeline.js
+++ b/src/pages/light-item-details/request-timelines/timeline.js
@@ -27,6 +27,7 @@ import { WalletContext } from 'contexts/wallet-context'
 import BNPropType from 'prop-types/bn'
 import { capitalizeFirstLetter } from 'utils/string'
 import { getTxPage } from 'utils/network-utils'
+import useGetLogs from 'hooks/get-logs'
 
 const StyledText = styled(Typography.Text)`
   text-transform: capitalize;
@@ -89,6 +90,7 @@ const Timeline = ({ request, requestID, item }) => {
     if (!request) return
     return bigNumberify(request.evidenceGroupID)
   }, [request])
+  const getLogs = useGetLogs(library)
 
   // Setup arbitrator instance.
   useEffect(() => {
@@ -129,24 +131,24 @@ const Timeline = ({ request, requestID, item }) => {
       // Fetch logs in parallel.
       const logsArr = (
         await Promise.all([
-          library.getLogs({
+          getLogs({
             ...gtcr.filters.Evidence(arbitrator.address, evidenceGroupID),
             fromBlock: 0
           }),
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...gtcr.filters.Ruling(arbitrator.address, disputeID),
                 fromBlock: 0
               })
             : null,
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...arbitrator.filters.AppealPossible(disputeID, gtcrAddr),
                 fromBlock: 0
               })
             : null,
           disputed
-            ? library.getLogs({
+            ? getLogs({
                 ...arbitrator.filters.AppealDecision(disputeID, gtcrAddr),
                 fromBlock: 0
               })


### PR DESCRIPTION
this is a hack. it works by forcibly rerouting
mainnet calls to a separate provider created from
the key in environment. currently using alchemy

also authored by @andreiMVP