### PR TITLE
fix(tcr-card): use valid networkId in place of undefined chainId

### DIFF
--- a/src/components/light-tcr-card-content.js
+++ b/src/components/light-tcr-card-content.js
@@ -29,17 +29,10 @@ const StyledResult = styled(Result)`
 
 const TCRCardContent = ({
   tcrAddress,
-  chainId,
   currentTCRAddress,
   ID,
   hideDetailsButton
 }) => {
-  console.log({
-    tcrAddress,
-    currentTCRAddress,
-    ID,
-    hideDetailsButton
-  })
   const { library, active, networkId } = useWeb3Context()
   const [error, setError] = useState()
   const gtcr = useMemo(() => {
@@ -83,12 +76,12 @@ const TCRCardContent = ({
           </StyledItemCol>
           <StyledItemCol>
             {!hideDetailsButton && (
-              <Link to={`/tcr/${chainId}/${currentTCRAddress}/${ID}`}>
+              <Link to={`/tcr/${networkId}/${currentTCRAddress}/${ID}`}>
                 <Button>Details</Button>
               </Link>
             )}
             <Link
-              to={`/tcr/${chainId}/${tcrAddress}`}
+              to={`/tcr/${networkId}/${tcrAddress}`}
               style={{ marginLeft: '12px' }}
             >
               <Button type="primary">Open List</Button>
@@ -130,12 +123,12 @@ const TCRCardContent = ({
         </div>
         <StyledItemCol>
           {!hideDetailsButton && (
-            <Link to={`/tcr/${chainId}/${currentTCRAddress}/${ID}`}>
+            <Link to={`/tcr/${networkId}/${currentTCRAddress}/${ID}`}>
               <Button>Details</Button>
             </Link>
           )}
           <Link
-            to={`/tcr/${chainId}/${tcrAddress}`}
+            to={`/tcr/${networkId}/${tcrAddress}`}
             style={{ marginLeft: '12px' }}
           >
             <Button type="primary">Open List</Button>

--- a/src/components/tcr-card-content.js
+++ b/src/components/tcr-card-content.js
@@ -29,7 +29,6 @@ const StyledResult = styled(Result)`
 
 const TCRCardContent = ({
   tcrAddress,
-  chainId,
   currentTCRAddress,
   ID,
   hideDetailsButton
@@ -77,12 +76,12 @@ const TCRCardContent = ({
           </StyledItemCol>
           <StyledItemCol>
             {!hideDetailsButton && (
-              <Link to={`/tcr/${chainId}/${currentTCRAddress}/${ID}`}>
+              <Link to={`/tcr/${networkId}/${currentTCRAddress}/${ID}`}>
                 <Button>Details</Button>
               </Link>
             )}
             <Link
-              to={`/tcr/${chainId}/${tcrAddress}`}
+              to={`/tcr/${networkId}/${tcrAddress}`}
               style={{ marginLeft: '12px' }}
             >
               <Button type="primary">Open List</Button>
@@ -124,12 +123,12 @@ const TCRCardContent = ({
         </div>
         <StyledItemCol>
           {!hideDetailsButton && (
-            <Link to={`/tcr/${chainId}/${currentTCRAddress}/${ID}`}>
+            <Link to={`/tcr/${networkId}/${currentTCRAddress}/${ID}`}>
               <Button>Details</Button>
             </Link>
           )}
           <Link
-            to={`/tcr/${chainId}/${tcrAddress}`}
+            to={`/tcr/${networkId}/${tcrAddress}`}
             style={{ marginLeft: '12px' }}
           >
             <Button type="primary">Open List</Button>

--- a/src/pages/items/item-card.js
+++ b/src/pages/items/item-card.js
@@ -134,7 +134,6 @@ const CardItemInfo = ({
     content = isTCRofTCRs ? (
       <TCRCardContent
         ID={item.tcrData.ID}
-        chainId={chainId}
         tcrAddress={item.columns[0].value}
         itemName={itemName}
         currentTCRAddress={tcrAddress}

--- a/src/pages/light-items/item-card.js
+++ b/src/pages/light-items/item-card.js
@@ -134,7 +134,6 @@ const CardItemInfo = ({
     content = isTCRofTCRs ? (
       <TCRCardContent
         ID={item.tcrData.ID}
-        chainId={chainId}
         tcrAddress={item.columns[0].value}
         itemName={itemName}
         currentTCRAddress={tcrAddress}


### PR DESCRIPTION
Removed the `chainId` argument from props since it never gets passed down from the parent component. Replaced with `networkId` variable provided by web3-react lib within the component.

fixes #249 fixes #247 