### PR TITLE
fix: address explorer link on goerli

### DIFF
--- a/src/utils/network-utils.js
+++ b/src/utils/network-utils.js
@@ -12,7 +12,7 @@ export const NETWORK_NAME = {
   [NETWORK.MAINNET]: 'mainnet',
   [NETWORK.ROPSTEN]: 'ropsten',
   [NETWORK.RINKEBY]: 'rinkeby',
-  [NETWORK.GOERLI]: 'göerli',
+  [NETWORK.GOERLI]: 'goerli',
   [NETWORK.KOVAN]: 'kovan',
   [NETWORK.XDAI]: 'xDai'
 }


### PR DESCRIPTION
`fix : address explorer link on goerli`

`closes #267` 