### PR TITLE
fix(tcr-view): add toLowerCase() for checksummed addresses

### DIFF
--- a/src/hooks/tcr-view.js
+++ b/src/hooks/tcr-view.js
@@ -274,7 +274,7 @@ const useTcrView = tcrAddress => {
       !library ||
       gtcr.address !== tcrAddress ||
       !metadataByTime ||
-      metadataByTime.address !== tcrAddress ||
+      metadataByTime.address.toLowerCase() !== tcrAddress.toLowerCase() ||
       !getLogs
     )
       return


### PR DESCRIPTION
this issue is due to some of the fetched addresses being checksummed depending on the chain.
while on mainnet one of the addresses is checksummed, another is lowercased. Opposite - for other chains.

fixes #265  