### PR TITLE
fix: updated goerli subgraph

### DIFF
--- a/src/config/tcr-addresses.ts
+++ b/src/config/tcr-addresses.ts
@@ -131,6 +131,6 @@ export const subgraphUrl = {
   '1':
     'https://api.thegraph.com/subgraphs/name/greenlucid/legacy-curate-mainnet',
   '5':
-    'https://api.thegraph.com/subgraphs/name/shotaronowhere/curate-goerli-fix',
+    'https://api.thegraph.com/subgraphs/name/greenlucid/curate-goerli',
   '100': 'https://api.thegraph.com/subgraphs/name/greenlucid/legacy-curate-xdai'
 } as const


### PR DESCRIPTION
Still updating, can be merged when fully indexed

https://thegraph.com/hosted-service/subgraph/greenlucid/curate-goerli

Whenever subgraphs under the kleros orgs are updated, then this should be updated as well (maybe under kleros/curate-goerli) as a commit in this PR https://github.com/kleros/gtcr/pull/313