### PR TITLE
fix: appeals in request-timelines

### DIFF
--- a/src/utils/graphql/classic-item-details.js
+++ b/src/utils/graphql/classic-item-details.js
@@ -45,6 +45,9 @@ const CLASSIC_ITEM_DETAILS_QUERY = gql`
           hasPaidChallenger
           amountPaidRequester
           amountPaidChallenger
+          txHashAppealPossible
+          appealedAt
+          txHashAppealDecision
         }
       }
     }

--- a/src/utils/graphql/item-details.js
+++ b/src/utils/graphql/item-details.js
@@ -45,6 +45,9 @@ const LIGHT_ITEM_DETAILS_QUERY = gql`
           hasPaidChallenger
           amountPaidRequester
           amountPaidChallenger
+          txHashAppealPossible
+          appealedAt
+          txHashAppealDecision
         }
       }
     }


### PR DESCRIPTION
appeals now render properly
also added additional information
in case only the loser funded the appeal
of the last round