### PR TITLE
fix(web): submit-booleans-and-default-types-as-strings

### DIFF
--- a/src/components/input-selector.tsx
+++ b/src/components/input-selector.tsx
@@ -138,7 +138,7 @@ const InputSelector: React.FC<InputSelectorProps> = p => {
             <Form.Item label={label} style={{ display: 'flex' }}>
               <Switch
                 {...field}
-                onChange={value => p.setFieldValue(name, value)}
+                onChange={value => p.setFieldValue(name, String(value))}
               />
             </Form.Item>
           )}

--- a/src/pages/item-details/modals/submit.tsx
+++ b/src/pages/item-details/modals/submit.tsx
@@ -74,16 +74,18 @@ const _SubmissionForm: React.FC<{
 
 const SubmissionForm: React.ComponentType<any> = withFormik({
   mapPropsToValues: ({ columns, initialValues }) =>
-    columns.reduce(
-      (acc: any, curr: any, i: number) => ({
+    columns.reduce((acc: any, curr: any, i: number) => {
+      const isBooleanType = curr.type === ItemTypes.BOOLEAN
+      const defaultValue = initialValues
+        ? initialValues[i]
+        : // @ts-ignore
+          typeDefaultValues[curr.type]
+
+      return {
         ...acc,
-        [curr.label]: initialValues
-          ? initialValues[i]
-          : // @ts-ignore
-            typeDefaultValues[curr.type]
-      }),
-      {}
-    ),
+        [curr.label]: isBooleanType ? String(defaultValue) : defaultValue
+      }
+    }, {}),
   handleSubmit: (values, { props, resetForm }) => {
     props.postSubmit(values, props.columns, resetForm)
   },

--- a/src/pages/item-details/modals/submit.tsx
+++ b/src/pages/item-details/modals/submit.tsx
@@ -75,7 +75,6 @@ const _SubmissionForm: React.FC<{
 const SubmissionForm: React.ComponentType<any> = withFormik({
   mapPropsToValues: ({ columns, initialValues }) =>
     columns.reduce((acc: any, curr: any, i: number) => {
-      const isBooleanType = curr.type === ItemTypes.BOOLEAN
       const defaultValue = initialValues
         ? initialValues[i]
         : // @ts-ignore
@@ -83,7 +82,7 @@ const SubmissionForm: React.ComponentType<any> = withFormik({
 
       return {
         ...acc,
-        [curr.label]: isBooleanType ? String(defaultValue) : defaultValue
+        [curr.label]: String(defaultValue)
       }
     }, {}),
   handleSubmit: (values, { props, resetForm }) => {

--- a/src/pages/light-item-details/modals/submit.tsx
+++ b/src/pages/light-item-details/modals/submit.tsx
@@ -88,7 +88,6 @@ const _SubmissionForm: React.FC<{
 const SubmissionForm: React.ComponentType<any> = withFormik({
   mapPropsToValues: ({ columns, initialValues }: any) =>
     columns.reduce((acc: any, curr: any, i: number) => {
-      const isBooleanType = curr.type === ItemTypes.BOOLEAN
       const defaultValue = initialValues
         ? initialValues[i]
         : // @ts-ignore
@@ -96,7 +95,7 @@ const SubmissionForm: React.ComponentType<any> = withFormik({
 
       return {
         ...acc,
-        [curr.label]: isBooleanType ? String(defaultValue) : defaultValue
+        [curr.label]: String(defaultValue)
       }
     }, {}),
   handleSubmit: (values, { props, resetForm }) => {

--- a/src/pages/light-item-details/modals/submit.tsx
+++ b/src/pages/light-item-details/modals/submit.tsx
@@ -87,16 +87,18 @@ const _SubmissionForm: React.FC<{
 
 const SubmissionForm: React.ComponentType<any> = withFormik({
   mapPropsToValues: ({ columns, initialValues }: any) =>
-    columns.reduce(
-      (acc: any, curr: any, i: number) => ({
+    columns.reduce((acc: any, curr: any, i: number) => {
+      const isBooleanType = curr.type === ItemTypes.BOOLEAN
+      const defaultValue = initialValues
+        ? initialValues[i]
+        : // @ts-ignore
+          typeDefaultValues[curr.type]
+
+      return {
         ...acc,
-        [curr.label]: initialValues
-          ? initialValues[i]
-          : // @ts-ignore
-            typeDefaultValues[curr.type]
-      }),
-      {}
-    ),
+        [curr.label]: isBooleanType ? String(defaultValue) : defaultValue
+      }
+    }, {}),
   handleSubmit: (values, { props, resetForm }) => {
     props.postSubmit(values, props.columns, resetForm)
   },


### PR DESCRIPTION
examples:

before this change, the default value of number was number, but once you modified it, it became a string.
and the default value of boolean was boolean, and once you modified it, it stayed boolean too, when it shouldve been a string for being uploaded into the IPFS json string object

ATQ Registry,
before (without inputting anything in the number value):
<img width="470" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/6bf343df-c099-4010-9b8f-29f94290dda2">

after (without inputting anything in the number value):
<img width="478" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/10958dcf-a49e-4d1d-b2fc-72ddd8d1f6a6">

---------------------------------------------------------------------------------------

ATQ Registry,
before (inputting something in the number value):
<img width="476" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/cbe4bd45-061c-4c9f-bd20-c72998fbd6ed">

after (inputting something in the number value):
<img width="484" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/731befe5-29cb-4296-b1d3-6a2a26f609e7">

---------------------------------------------------------------------------------------

AT Registry,
before and after are the same:
<img width="631" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/0bab2c45-6e30-49d0-976f-f280c94ffe0d">

---------------------------------------------------------------------------------------

Token Registry,
before and after are the same:
<img width="704" alt="image" src="https://github.com/kleros/gtcr/assets/102478601/2c33c173-ded3-47de-82b3-7fba4c155f3a">





