### PR TITLE
fix: use latest metaevidence in permanent item details

### DIFF
--- a/src/utils/graphql/permanent-item-details.ts
+++ b/src/utils/graphql/permanent-item-details.ts
@@ -69,7 +69,11 @@ const PERMANENT_ITEM_DETAILS_QUERY = gql`
         arbitrator {
           id
         }
-        arbitrationSettings {
+        arbitrationSettings(
+          orderBy: timestamp
+          orderDirection: desc
+          first: 1
+        ) {
           timestamp
           arbitratorExtraData
           metaEvidenceURI


### PR DESCRIPTION
## Issue
on PGCTR, the item page renders the wrong metaevidence and may cause issues when displaying the item info.

## Summary
- order permanent item detail arbitration settings by newest timestamp
- limit the detail query to the latest setting so item pages use the same MetaEvidence as list previews

## Verification
- `corepack yarn eslint src/utils/graphql/permanent-item-details.ts`
- `corepack yarn build`

Note: repo-wide `corepack yarn lint` still reports two pre-existing `curly` errors in remove modal files unrelated to this change.