### PR TITLE
feat: render evidence descriptions as Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^18.3.1",
     "react-error-boundary": "^6.1.1",
     "react-is": "^16.13.1",
+    "react-markdown": "^9.0.1",
     "react-router-dom": "^6.30.3",
     "react-toastify": "^11.0.5",
     "styled-components": "^5.3.11",

--- a/src/components/evidence-description.tsx
+++ b/src/components/evidence-description.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import styled from 'styled-components'
+import ExternalLinkWarning from 'components/external-link-warning'
+import { isSafeNavigationUrl } from 'utils/url-validation'
+
+const MARKDOWN_ELEMENTS = [
+  'a',
+  'blockquote',
+  'br',
+  'code',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'strong',
+  'ul',
+]
+
+const Container = styled.div`
+  overflow-wrap: anywhere;
+  white-space: normal;
+  font-weight: 400;
+  color: ${({ theme }) => theme.textPrimary};
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  p,
+  blockquote,
+  ol,
+  ul,
+  pre {
+    margin: 0 0 0.75em;
+  }
+
+  p,
+  li {
+    white-space: pre-line;
+  }
+
+  ol,
+  ul {
+    padding-left: 1.5em;
+  }
+
+  li + li {
+    margin-top: 0.25em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0.75em 0 0.4em;
+    font-size: 1em;
+    font-weight: 600;
+  }
+
+  a {
+    color: ${({ theme }) => theme.linkColor};
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  blockquote {
+    padding-left: 0.75em;
+    border-left: 3px solid ${({ theme }) => theme.borderColor};
+    color: ${({ theme }) => theme.textSecondary};
+  }
+
+  code {
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    background: ${({ theme }) => theme.quaternaryColor};
+  }
+
+  pre {
+    overflow-x: auto;
+    padding: 0.75em;
+    border-radius: 4px;
+    background: ${({ theme }) => theme.elevatedBackground};
+
+    code {
+      padding: 0;
+      background: transparent;
+    }
+  }
+`
+
+interface EvidenceDescriptionProps {
+  children?: string | null
+}
+
+interface EvidenceLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string
+}
+
+const EvidenceLink = ({ href, children, ...props }: EvidenceLinkProps) => {
+  const [warningVisible, setWarningVisible] = useState(false)
+  const safeHref = isSafeNavigationUrl(href) ? href : undefined
+
+  if (!safeHref) return <>{children}</>
+
+  const closeWarning = () => setWarningVisible(false)
+
+  const openLink = () => {
+    closeWarning()
+    window.open(safeHref, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <>
+      <a
+        {...props}
+        href={safeHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(event) => {
+          event.preventDefault()
+          setWarningVisible(true)
+        }}
+      >
+        {children}
+      </a>
+      <ExternalLinkWarning
+        visible={warningVisible}
+        url={safeHref}
+        onConfirm={openLink}
+        onCancel={closeWarning}
+      />
+    </>
+  )
+}
+
+const EvidenceDescription = ({ children }: EvidenceDescriptionProps) => (
+  <Container>
+    <ReactMarkdown
+      allowedElements={MARKDOWN_ELEMENTS}
+      components={{
+        a: ({ node: _node, ...props }) => <EvidenceLink {...props} />,
+      }}
+      skipHtml
+      unwrapDisallowed
+    >
+      {children ?? ''}
+    </ReactMarkdown>
+  </Container>
+)
+
+export default EvidenceDescription

--- a/src/components/permanent-request-timelines.tsx
+++ b/src/components/permanent-request-timelines.tsx
@@ -13,6 +13,7 @@ import {
   Col,
 } from 'components/ui'
 import Icon from 'components/ui/Icon'
+import EvidenceDescription from 'components/evidence-description'
 import EvidenceFileLink from 'components/evidence-file-link'
 import useUrlChainId from 'hooks/use-url-chain-id'
 import ETHAddress from 'components/eth-address'
@@ -76,12 +77,6 @@ const StyledCard = styled(Card)`
       }
     `,
   )}
-`
-
-const StyledEvidenceTitle = styled.div`
-  white-space: pre-line;
-  font-weight: 400;
-  color: ${({ theme }) => theme.textPrimary};
 `
 
 const secondTimestamp = (timestamp: string | number | null | undefined) =>
@@ -408,7 +403,7 @@ const Timeline = ({ submission, item, metaEvidence }: TimelineProps) => {
             extra={fileURI && <EvidenceFileLink fileURI={fileURI} />}
           >
             <Card.Meta
-              title={<StyledEvidenceTitle>{description}</StyledEvidenceTitle>}
+              title={<EvidenceDescription>{description}</EvidenceDescription>}
               description={submissionTime}
             />
           </StyledCard>

--- a/src/components/request-timelines.tsx
+++ b/src/components/request-timelines.tsx
@@ -24,6 +24,7 @@ import {
 import { capitalizeFirstLetter } from 'utils/string'
 import { getTxPage } from 'utils/network-utils'
 import { parseIpfs } from 'utils/ipfs-parse'
+import EvidenceDescription from 'components/evidence-description'
 import EvidenceFileLink from 'components/evidence-file-link'
 import ClassicEvidenceModal from 'pages/item-details/modals/evidence'
 import LightEvidenceModal from 'pages/light-item-details/modals/evidence'
@@ -82,12 +83,6 @@ const StyledCard = styled(Card)`
       }
     `,
   )}
-`
-
-const StyledEvidenceTitle = styled.div`
-  white-space: pre-line;
-  font-weight: 400;
-  color: ${({ theme }) => theme.textPrimary};
 `
 
 const secondTimestamp = (timestamp: string | number | null | undefined) =>
@@ -326,7 +321,7 @@ const Timeline = ({ request, item, metaEvidence }: TimelineProps) => {
             extra={fileURI && <EvidenceFileLink fileURI={fileURI} />}
           >
             <Card.Meta
-              title={<StyledEvidenceTitle>{description}</StyledEvidenceTitle>}
+              title={<EvidenceDescription>{description}</EvidenceDescription>}
               description={submissionTime}
             />
           </StyledCard>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9599,6 +9599,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-error-boundary: "npm:^6.1.1"
     react-is: "npm:^16.13.1"
+    react-markdown: "npm:^9.0.1"
     react-router-dom: "npm:^6.30.3"
     react-toastify: "npm:^11.0.5"
     styled-components: "npm:^5.3.11"


### PR DESCRIPTION
## Summary

Evidence descriptions are currently displayed as plain text, so Markdown submitted by parties is shown verbatim. This makes structured arguments and source lists harder for Curate reviewers to scan.

This change renders evidence descriptions as Markdown in both classic/light and permanent request timelines.

## Before and after

The same illustrative evidence is used in both screenshots.

| Before — raw Markdown | After — rendered Markdown |
| --- | --- |
| ![Evidence description displayed as raw Markdown](https://raw.githubusercontent.com/lovon-spec/gtcr/assets-markdown-evidence/.github/pr-assets/evidence-markdown-before.png) | ![Evidence description rendered as structured Markdown](https://raw.githubusercontent.com/lovon-spec/gtcr/assets-markdown-evidence/.github/pr-assets/evidence-markdown-after.png) |

## Safety

- Raw HTML is ignored.
- An explicit element allowlist excludes embedded images.
- Only absolute HTTPS links are enabled, and they use Curate's existing external-link warning.
- Existing plain-text line breaks remain intact.

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- Manual Markdown, line-break, and unsafe-content checks

Closes #394.
